### PR TITLE
Add ubuntu wily (15.10) support

### DIFF
--- a/hyper-bootstrap-xen.sh
+++ b/hyper-bootstrap-xen.sh
@@ -20,7 +20,7 @@ SUPPORT_EMAIL="support@hyper.sh"
 ########## Constant ##########
 SUPPORT_DISTRO=(debian ubuntu fedora centos linuxmint)
 LINUX_MINT_CODE=(rafaela rebecca qiana)
-UBUNTU_CODE=(trusty utopic vivid)
+UBUNTU_CODE=(trusty utopic vivid wily)
 DEBIAN_CODE=(jessie wheezy)
 CENTOS_VER=(6 7)
 FEDORA_VER=(20 21 22)

--- a/hyper-bootstrap.sh
+++ b/hyper-bootstrap.sh
@@ -20,7 +20,7 @@ SUPPORT_EMAIL="support@hyper.sh"
 ########## Constant ##########
 SUPPORT_DISTRO=(debian ubuntu fedora centos linuxmint)
 LINUX_MINT_CODE=(rafaela rebecca qiana)
-UBUNTU_CODE=(trusty utopic vivid)
+UBUNTU_CODE=(trusty utopic vivid wily)
 DEBIAN_CODE=(jessie wheezy)
 CENTOS_VER=(6 7)
 FEDORA_VER=(20 21 22)


### PR DESCRIPTION
Both this installer and hyper itself works well in ubuntu wily (15.10), why not add support for it ! :smiley:
